### PR TITLE
Fix for running on Pepper with NAOqi 2.8.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,54 +2,89 @@ NAOqi DCM Driver
 ================
 
 The hardware interface to connect to Nao, Romeo, and Pepper robots. This is the new version of `nao_dcm_driver <https://github.com/ros-naoqi/nao_dcm_robot/tree/master/nao_dcm_driver>`_ that is now common for all robots.
-You can control the robot either by calling DCM commands, or using ALMotion (by default). 
+You can control the robot either by calling DCM commands, or using ALMotion (by default).
 When calling DCM commands, you can achieve faster control frequency but it can make the robot shaking because of the concurrence between DCM and ALMotion. Especially when using DCM, please be careful and use it at your own risks.
 
 What it does
-============
+++++++++++++
 
-The package allows to control a robot from ROS, while communicating with Naoqi. 
+The package allows to control a robot from ROS, while communicating with Naoqi.
 The package is inspired by nao_dcm_driver, however it does not require NAOqi SDK anymore and rather based on naoqi_libqi and naoqi_libqicore. The package is more generic, and it works with any of Nao, Romeo, and Pepper robots. It can run on a remote PC or locally on a robot (after compiling on OpenNAO VM, deploying to your robot, and using robot_ip:=127.0.0.1).
 
-How to use
-==========
+Development
++++++++++++
 
-##Dependencies
-To run, the driver requires the `naoqi_libqi`, `naoqi_libqicore` and `naoqi_bridge_msgs` packages. Those can be installed using apt-get (if they have been released for your ROS distro) or from source. Additionally, `pepper_meshes` and/or `nao_meshes` can be useful if you try to display the robot in RViz.
+This project must be part of a catkin workspace.
+Do not forget to source the workspace:
 
-Additionaly, you might need to install further dependencies with this command : apt install ros-noetic-gazebo-plugins ros-noetic-gazebo-ros ros-noetic-gazebo-ros-control ros-noetic-ros-control ros-noetic-ros-controllers python-rospkg python-yaml
-
-##Reperitory 
-You need to clone the following reperitorys ==  
-pepper_robot: https://github.com/linoxmo/pepper_robot.git
-pepper_dcm_robot: https://github.com/linoxmo/pepper_dcm_robot.git
-pepper_virtual: https://github.com/linoxmo/pepper_virtual.git
-naoqi_bridge: https://github.com/linoxmo/naoqi_bridge.git
-humanoid_msgs , camera_info_manager_py 
-
-
-and build them in the same workspace. 
-
-## Launch
-The driver can be launched using the following command:
 ```sh
-roslaunch naoqi_driver naoqi_driver.launch nao_ip:=<ip> nao_port:=<port> network_interface:=<interface> username:=<name> password:=<passwd>
-
-'''
-source path/setup.bash 
-
-roslaunch pepper_dcm_bringup pepper_dcm_bringup_position.launch robot_ip:=<ip> robot_port:=<port> network_interface:=<interface> username:=<user> password:=<password>
-'''
-       
-
+cd <catkin_ws>
+source devel/setup.bash
 ```
-Note that the username and password arguments are only required for robots running naoqi 2.9 or greater 
 
-:warning: naoqi_driver for melodic and greater have to be used for robots running naoqi 2.9 and greater
+Dependencies
+------------
 
-## Build status
+To build and run from source, the driver requires the `naoqi_libqi`, `naoqi_libqicore` and `naoqi_bridge_msgs` packages.
+For ROS Noetic:
 
+```sh
+apt install ros-noetic-naoqi-libqi ros-noetic-naoqi-libqicore ros-noetic-naoqi-bridge-msgs
+```
 
-_
+Additionally, `pepper_meshes` and/or `nao_meshes` can be useful if you try to display the robot in RViz.
 
+You need to clone the following reperitories under `src/`:
+- pepper_robot: https://github.com/linoxmo/pepper_robot.git
+- pepper_dcm_robot: https://github.com/linoxmo/pepper_dcm_robot.git
+- pepper_virtual: https://github.com/linoxmo/pepper_virtual.git
+- naoqi_bridge: https://github.com/linoxmo/naoqi_bridge.git
 
+For ROS Noetic, you also need to clone the following repositories:
+- humanoid_msgs: https://github.com/ahornung/humanoid_msgs.git
+- camera_info_manager_py: https://github.com/ros-perception/camera_info_manager_py.git
+
+```sh
+rosdep install -y --from-paths src -i src/pepper_dcm_robot/pepper_dcm_bringup/
+```
+
+The packages `python-rospkg` and `python-yaml` cannot be installed on Ubuntu 20.04,
+install `python3-rospkg` and `python3-yaml` instead.
+
+Check the missing packages with:
+
+```sh
+rosdep check --from-paths src -i src/pepper_dcm_robot/pepper_dcm_bringup/
+```
+
+You might need to install further dependencies:
+
+```sh
+apt install ros-noetic-rgbd-launch
+apt install ros-noetic-gazebo-plugins ros-noetic-gazebo-ros ros-noetic-gazebo-ros-control ros-noetic-ros-control ros-noetic-ros-controllers python-rospkg python-yaml
+```
+
+Build
+-----
+
+Use `catkin_make` normally to build the packages.
+
+Launch
+------
+
+The driver can be launched using the following command for NAOqi 2.5:
+
+```sh
+roslaunch pepper_dcm_bringup pepper_dcm_bringup_position.launch robot_ip:=<ip>
+```
+
+> You can set a specific port with `robot_port:=<port>`. It is set to `9559` by default.
+
+For NAOqi 2.9, you must provide the robot's credentials:
+
+```sh
+roslaunch pepper_dcm_bringup pepper_dcm_bringup_position.launch robot_ip:=<ip> user:=<user> password:=<password>
+```
+
+> You can set a specific port with `robot_port:=<port>`. It is set to `9503` by default
+  if `user` or `password` are provided.

--- a/src/dcm.cpp
+++ b/src/dcm.cpp
@@ -27,7 +27,7 @@ DCM::DCM(const qi::SessionPtr& session,
 {
   try
   {
-    dcm_proxy_ = session->service("DCM");
+    dcm_proxy_ = session->service("DCM").value();
   }
   catch (const std::exception& e)
   {

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -42,7 +42,7 @@ Diagnostics::Diagnostics(const qi::SessionPtr& session,
   //connect to Memmory proxy
   try
   {
-    memory_proxy_ = session->service("ALMemory");
+    memory_proxy_ = session->service("ALMemory").value();
   }
   catch (const std::exception& e)
   {
@@ -67,7 +67,7 @@ Diagnostics::Diagnostics(const qi::SessionPtr& session,
   try
   {
     if ((robot == "pepper") || (robot == "juliette") || (robot == "nao")) {
-      qi::AnyObject body_temperature_ = session->service("ALBodyTemperature");
+      qi::AnyObject body_temperature_ = session->service("ALBodyTemperature").value();
       body_temperature_.call<void>("setEnableNotifications", true);
     }
   }

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -25,7 +25,7 @@ Memory::Memory(const qi::SessionPtr& session)
 {
   try
   {
-    memory_proxy_ = session->service("ALMemory");
+    memory_proxy_ = session->service("ALMemory").value();
   }
   catch (const std::exception& e)
   {

--- a/src/motion.cpp
+++ b/src/motion.cpp
@@ -26,7 +26,7 @@ Motion::Motion(const qi::SessionPtr& session)
 {
   try
   {
-    motion_proxy_ = session->service("ALMotion");
+    motion_proxy_ = session->service("ALMotion").value();
   }
   catch (const std::exception& e)
   {

--- a/src/robot_driver.cpp
+++ b/src/robot_driver.cpp
@@ -75,32 +75,39 @@ int main(int argc, char **argv)
   }
 
   // Load Params from Parameter Server
-  int pport = 9503;
   std::string pip = "127.0.0.1";
+  int pport = 0;
   std::string roscore_ip = "127.0.0.1";
   std::string network_interface = "eth0";
-  std::string username;
+  std::string user;
   std::string password;
   nh.getParam("RobotIP", pip);
   nh.getParam("RobotPort", pport);
   nh.getParam("DriverBrokerIP", roscore_ip);
   nh.getParam("network_interface", network_interface);
-  nh.getParam("user", username);
+  nh.getParam("user", user);
   nh.getParam("password", password);
   setMasterURINet("http://" + roscore_ip + ":11311", network_interface);
+  if (pport == 0) {
+    if (!user.empty() || !password.empty()) {
+      pport = 9503;
+    } else {
+      pport = 9559;
+    }
+  }
 
   //create a session
   qi::SessionPtr session = qi::makeSession();
   qi::SignalSpy connectedSpy(session->connected);
 
   std::string protocol = "tcp://";
-  bool secure_connection = (pport == 9503 && !username.empty() && !password.empty());
+  bool secure_connection = (pport == 9503 && !user.empty() && !password.empty());
 
-  if (secure_connection) 
+  if (secure_connection)
   {
     protocol = "tcps://";
     naoqi::DriverAuthenticatorFactory *factory = new naoqi::DriverAuthenticatorFactory;
-    factory->user = username;
+    factory->user = user;
     factory->pass = password;
     session->setClientAuthenticatorFactory(qi::ClientAuthenticatorFactoryPtr(factory));
     std::cout << "Secure connection configured" << std::endl;


### PR DESCRIPTION
- Doc fixes
- Warning fixes
- Fix passing user name
- Automatically attempt port 9663 if port was not specified and user name or password were provided.